### PR TITLE
Create tab selection view with grips

### DIFF
--- a/Controller/CarRecordsViewController.swift
+++ b/Controller/CarRecordsViewController.swift
@@ -34,6 +34,7 @@ class CarRecordsViewController: UIViewController {
     
     private func configureNavigationBarButtons() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(onAddButtonTap))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Tab Demo", style: .plain, target: self, action: #selector(onTabDemoButtonTap))
     }
     
     @objc private func onAddButtonTap() {
@@ -96,5 +97,11 @@ extension CarRecordsViewController: UITableViewDelegate, UITableViewDataSource {
         }
         
         return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+    
+    @objc private func onTabDemoButtonTap() {
+        let tabSelectionVC = TabSelectionViewController()
+        let navController = UINavigationController(rootViewController: tabSelectionVC)
+        present(navController, animated: true)
     }
 }

--- a/Controller/TabSelectionViewController.swift
+++ b/Controller/TabSelectionViewController.swift
@@ -1,0 +1,235 @@
+//
+//  TabSelectionViewController.swift
+//  CarDirectory
+//
+//  Created by Assistant on $(date)
+//  Copyright © 2020 Alexander Team. All rights reserved.
+//
+
+import UIKit
+
+class TabSelectionViewController: UIViewController {
+    
+    // MARK: - Properties
+    private var contentView: UIView!
+    private var selectionView: SelectionView?
+    private var isSelectionMode: Bool = false
+    
+    // Mock tablature content view
+    private var tablatureView: UIView!
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupNavigationBar()
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        
+        // Create content container
+        contentView = UIView()
+        contentView.backgroundColor = .secondarySystemBackground
+        contentView.layer.cornerRadius = 8
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentView)
+        
+        // Setup tablature mock view
+        setupTablatureView()
+        
+        // Layout constraints
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
+    }
+    
+    private func setupTablatureView() {
+        tablatureView = UIView()
+        tablatureView.backgroundColor = .systemBackground
+        tablatureView.layer.cornerRadius = 4
+        tablatureView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(tablatureView)
+        
+        // Create mock tablature lines
+        createMockTablature()
+        
+        NSLayoutConstraint.activate([
+            tablatureView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            tablatureView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            tablatureView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            tablatureView.heightAnchor.constraint(equalToConstant: 200)
+        ])
+        
+        // Add tap gesture to enable selection
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTablatureTap(_:)))
+        tablatureView.addGestureRecognizer(tapGesture)
+    }
+    
+    private func createMockTablature() {
+        let stringNames = ["e", "B", "G", "D", "A", "E"]
+        let lineHeight: CGFloat = 30
+        
+        for (index, stringName) in stringNames.enumerated() {
+            // String name label
+            let nameLabel = UILabel()
+            nameLabel.text = stringName
+            nameLabel.font = .systemFont(ofSize: 16, weight: .medium)
+            nameLabel.textAlignment = .center
+            nameLabel.translatesAutoresizingMaskIntoConstraints = false
+            tablatureView.addSubview(nameLabel)
+            
+            // Tablature line
+            let lineView = UIView()
+            lineView.backgroundColor = .separator
+            lineView.translatesAutoresizingMaskIntoConstraints = false
+            tablatureView.addSubview(lineView)
+            
+            let yPosition = CGFloat(index) * lineHeight + 40
+            
+            NSLayoutConstraint.activate([
+                nameLabel.leadingAnchor.constraint(equalTo: tablatureView.leadingAnchor, constant: 10),
+                nameLabel.centerYAnchor.constraint(equalTo: tablatureView.topAnchor, constant: yPosition),
+                nameLabel.widthAnchor.constraint(equalToConstant: 20),
+                
+                lineView.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 10),
+                lineView.trailingAnchor.constraint(equalTo: tablatureView.trailingAnchor, constant: -10),
+                lineView.centerYAnchor.constraint(equalTo: nameLabel.centerYAnchor),
+                lineView.heightAnchor.constraint(equalToConstant: 1)
+            ])
+            
+            // Add some fret numbers
+            addFretNumbers(to: lineView, yPosition: yPosition)
+        }
+    }
+    
+    private func addFretNumbers(to lineView: UIView, yPosition: CGFloat) {
+        let fretNumbers = ["0", "3", "0", "0", "7", "0"]
+        let spacing: CGFloat = 60
+        
+        for (index, number) in fretNumbers.enumerated() {
+            if number != "0" {
+                let numberLabel = UILabel()
+                numberLabel.text = number
+                numberLabel.font = .monospacedDigitSystemFont(ofSize: 14, weight: .medium)
+                numberLabel.textAlignment = .center
+                numberLabel.translatesAutoresizingMaskIntoConstraints = false
+                tablatureView.addSubview(numberLabel)
+                
+                NSLayoutConstraint.activate([
+                    numberLabel.leadingAnchor.constraint(equalTo: lineView.leadingAnchor, constant: CGFloat(index) * spacing + 40),
+                    numberLabel.centerYAnchor.constraint(equalTo: tablatureView.topAnchor, constant: yPosition),
+                    numberLabel.widthAnchor.constraint(equalToConstant: 20)
+                ])
+            }
+        }
+    }
+    
+    private func setupNavigationBar() {
+        title = "Tab Selection Demo"
+        
+        let selectButton = UIBarButtonItem(
+            title: isSelectionMode ? "Done" : "Select",
+            style: .plain,
+            target: self,
+            action: #selector(toggleSelectionMode)
+        )
+        navigationItem.rightBarButtonItem = selectButton
+    }
+    
+    // MARK: - Actions
+    @objc private func toggleSelectionMode() {
+        isSelectionMode.toggle()
+        
+        if isSelectionMode {
+            // Enable selection mode but don't create selection until user taps
+            navigationItem.rightBarButtonItem?.title = "Done"
+        } else {
+            // Disable selection mode
+            removeSelection()
+            navigationItem.rightBarButtonItem?.title = "Select"
+        }
+    }
+    
+    @objc private func handleTablatureTap(_ gesture: UITapGestureRecognizer) {
+        guard isSelectionMode else { return }
+        
+        let location = gesture.location(in: tablatureView)
+        
+        if selectionView == nil {
+            createSelection(at: location)
+        } else {
+            // Move existing selection or create new one
+            removeSelection()
+            createSelection(at: location)
+        }
+    }
+    
+    private func createSelection(at point: CGPoint) {
+        // Create selection with initial size
+        let selectionFrame = CGRect(
+            x: max(0, point.x - 50),
+            y: max(0, point.y - 30),
+            width: 100,
+            height: 60
+        )
+        
+        selectionView = SelectionView(frame: selectionFrame)
+        selectionView?.delegate = self
+        tablatureView.addSubview(selectionView!)
+        
+        // Animate in
+        selectionView?.alpha = 0
+        selectionView?.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        
+        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5) {
+            self.selectionView?.alpha = 1
+            self.selectionView?.transform = .identity
+        }
+    }
+    
+    private func removeSelection() {
+        guard let selectionView = selectionView else { return }
+        
+        UIView.animate(withDuration: 0.2) {
+            selectionView.alpha = 0
+            selectionView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        } completion: { _ in
+            selectionView.removeFromSuperview()
+            self.selectionView = nil
+        }
+    }
+}
+
+// MARK: - SelectionViewDelegate
+extension TabSelectionViewController: SelectionViewDelegate {
+    func selectionView(_ selectionView: SelectionView, didChangeFrame frame: CGRect) {
+        // Handle selection frame changes
+        print("Selection frame changed: \(frame)")
+        
+        // Ensure selection stays within bounds
+        var constrainedFrame = frame
+        constrainedFrame.origin.x = max(0, min(frame.origin.x, tablatureView.bounds.width - frame.width))
+        constrainedFrame.origin.y = max(0, min(frame.origin.y, tablatureView.bounds.height - frame.height))
+        
+        if constrainedFrame != frame {
+            selectionView.frame = constrainedFrame
+        }
+    }
+    
+    func selectionView(_ selectionView: SelectionView, didBeginSelection frame: CGRect) {
+        print("Selection began: \(frame)")
+        // Could add haptic feedback here
+        let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
+        impactFeedback.impactOccurred()
+    }
+    
+    func selectionView(_ selectionView: SelectionView, didEndSelection frame: CGRect) {
+        print("Selection ended: \(frame)")
+        // Could save selection state or trigger other actions
+    }
+}

--- a/View/GripView.swift
+++ b/View/GripView.swift
@@ -1,0 +1,150 @@
+//
+//  GripView.swift
+//  CarDirectory
+//
+//  Created by Assistant on $(date)
+//  Copyright © 2020 Alexander Team. All rights reserved.
+//
+
+import UIKit
+
+enum GripPosition {
+    case topLeft, topCenter, topRight
+    case centerLeft, centerRight
+    case bottomLeft, bottomCenter, bottomRight
+}
+
+protocol GripViewDelegate: AnyObject {
+    func gripView(_ gripView: GripView, didPanWithTranslation translation: CGPoint, state: UIGestureRecognizer.State)
+}
+
+class GripView: UIView {
+    
+    // MARK: - Properties
+    weak var delegate: GripViewDelegate?
+    let position: GripPosition
+    private let gripSize: CGFloat
+    
+    // MARK: - Initialization
+    init(position: GripPosition, size: CGFloat) {
+        self.position = position
+        self.gripSize = size
+        super.init(frame: CGRect(x: 0, y: 0, width: size, height: size))
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    private func setupView() {
+        backgroundColor = .systemGreen
+        layer.cornerRadius = gripSize / 2
+        layer.borderWidth = 1.0
+        layer.borderColor = UIColor.white.cgColor
+        
+        // Add shadow for better visibility
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 1)
+        layer.shadowOpacity = 0.3
+        layer.shadowRadius = 2
+        
+        setupGestures()
+        setupArrow()
+    }
+    
+    private func setupArrow() {
+        // Create arrow shape based on position
+        let arrowLayer = CAShapeLayer()
+        let arrowPath = createArrowPath()
+        
+        arrowLayer.path = arrowPath.cgPath
+        arrowLayer.fillColor = UIColor.white.cgColor
+        arrowLayer.strokeColor = UIColor.clear.cgColor
+        
+        layer.addSublayer(arrowLayer)
+    }
+    
+    private func createArrowPath() -> UIBezierPath {
+        let path = UIBezierPath()
+        let center = CGPoint(x: gripSize / 2, y: gripSize / 2)
+        let arrowSize: CGFloat = 6
+        
+        switch position {
+        case .topLeft, .bottomRight:
+            // Diagonal resize cursor (↖ ↘)
+            path.move(to: CGPoint(x: center.x - arrowSize/2, y: center.y - arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y + arrowSize/2))
+            path.move(to: CGPoint(x: center.x - arrowSize/2, y: center.y + arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y - arrowSize/2))
+            
+        case .topRight, .bottomLeft:
+            // Diagonal resize cursor (↗ ↙)
+            path.move(to: CGPoint(x: center.x - arrowSize/2, y: center.y + arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y - arrowSize/2))
+            path.move(to: CGPoint(x: center.x - arrowSize/2, y: center.y - arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y + arrowSize/2))
+            
+        case .topCenter, .bottomCenter:
+            // Vertical resize cursor (↕)
+            path.move(to: CGPoint(x: center.x, y: center.y - arrowSize))
+            path.addLine(to: CGPoint(x: center.x - 3, y: center.y - arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + 3, y: center.y - arrowSize/2))
+            path.close()
+            
+            path.move(to: CGPoint(x: center.x, y: center.y + arrowSize))
+            path.addLine(to: CGPoint(x: center.x - 3, y: center.y + arrowSize/2))
+            path.addLine(to: CGPoint(x: center.x + 3, y: center.y + arrowSize/2))
+            path.close()
+            
+        case .centerLeft, .centerRight:
+            // Horizontal resize cursor (↔)
+            path.move(to: CGPoint(x: center.x - arrowSize, y: center.y))
+            path.addLine(to: CGPoint(x: center.x - arrowSize/2, y: center.y - 3))
+            path.addLine(to: CGPoint(x: center.x - arrowSize/2, y: center.y + 3))
+            path.close()
+            
+            path.move(to: CGPoint(x: center.x + arrowSize, y: center.y))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y - 3))
+            path.addLine(to: CGPoint(x: center.x + arrowSize/2, y: center.y + 3))
+            path.close()
+        }
+        
+        return path
+    }
+    
+    private func setupGestures() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        addGestureRecognizer(panGesture)
+    }
+    
+    // MARK: - Gesture Handling
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: superview)
+        delegate?.gripView(self, didPanWithTranslation: translation, state: gesture.state)
+    }
+    
+    // MARK: - Visual Feedback
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        animatePress(pressed: true)
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        animatePress(pressed: false)
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        animatePress(pressed: false)
+    }
+    
+    private func animatePress(pressed: Bool) {
+        UIView.animate(withDuration: 0.1, delay: 0, options: [.allowUserInteraction]) {
+            self.transform = pressed ? CGAffineTransform(scaleX: 1.2, y: 1.2) : .identity
+            self.alpha = pressed ? 0.8 : 1.0
+        }
+    }
+}

--- a/View/SelectionView.swift
+++ b/View/SelectionView.swift
@@ -1,0 +1,246 @@
+//
+//  SelectionView.swift
+//  CarDirectory
+//
+//  Created by Assistant on $(date)
+//  Copyright © 2020 Alexander Team. All rights reserved.
+//
+
+import UIKit
+
+protocol SelectionViewDelegate: AnyObject {
+    func selectionView(_ selectionView: SelectionView, didChangeFrame frame: CGRect)
+    func selectionView(_ selectionView: SelectionView, didBeginSelection frame: CGRect)
+    func selectionView(_ selectionView: SelectionView, didEndSelection frame: CGRect)
+}
+
+class SelectionView: UIView {
+    
+    // MARK: - Properties
+    weak var delegate: SelectionViewDelegate?
+    
+    private var borderLayer: CAShapeLayer!
+    private var gripViews: [GripView] = []
+    private var initialFrame: CGRect = .zero
+    private var initialTouchPoint: CGPoint = .zero
+    
+    // Selection styling
+    var borderColor: UIColor = .systemGreen {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    var borderWidth: CGFloat = 2.0 {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    var fillColor: UIColor = UIColor.systemGreen.withAlphaComponent(0.2) {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    var gripSize: CGFloat = 20.0 {
+        didSet {
+            setupGrips()
+        }
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+    
+    // MARK: - Setup
+    private func setupView() {
+        backgroundColor = .clear
+        isUserInteractionEnabled = true
+        
+        setupBorder()
+        setupGrips()
+        setupGestures()
+    }
+    
+    private func setupBorder() {
+        borderLayer = CAShapeLayer()
+        borderLayer.fillColor = fillColor.cgColor
+        borderLayer.strokeColor = borderColor.cgColor
+        borderLayer.lineWidth = borderWidth
+        borderLayer.lineDashPattern = [5, 3] // Dashed border like in Songsterr
+        layer.addSublayer(borderLayer)
+    }
+    
+    private func setupGrips() {
+        // Remove existing grips
+        gripViews.forEach { $0.removeFromSuperview() }
+        gripViews.removeAll()
+        
+        // Create 8 grip points (corners and midpoints)
+        let gripPositions: [GripPosition] = [.topLeft, .topCenter, .topRight, .centerLeft, .centerRight, .bottomLeft, .bottomCenter, .bottomRight]
+        
+        for position in gripPositions {
+            let gripView = GripView(position: position, size: gripSize)
+            gripView.delegate = self
+            addSubview(gripView)
+            gripViews.append(gripView)
+        }
+    }
+    
+    private func setupGestures() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        addGestureRecognizer(panGesture)
+    }
+    
+    // MARK: - Layout
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateBorderPath()
+        positionGrips()
+    }
+    
+    private func updateBorderPath() {
+        let path = UIBezierPath(rect: bounds)
+        borderLayer.path = path.cgPath
+        borderLayer.frame = bounds
+    }
+    
+    private func positionGrips() {
+        let halfGrip = gripSize / 2
+        
+        for gripView in gripViews {
+            var center: CGPoint
+            
+            switch gripView.position {
+            case .topLeft:
+                center = CGPoint(x: halfGrip, y: halfGrip)
+            case .topCenter:
+                center = CGPoint(x: bounds.midX, y: halfGrip)
+            case .topRight:
+                center = CGPoint(x: bounds.maxX - halfGrip, y: halfGrip)
+            case .centerLeft:
+                center = CGPoint(x: halfGrip, y: bounds.midY)
+            case .centerRight:
+                center = CGPoint(x: bounds.maxX - halfGrip, y: bounds.midY)
+            case .bottomLeft:
+                center = CGPoint(x: halfGrip, y: bounds.maxY - halfGrip)
+            case .bottomCenter:
+                center = CGPoint(x: bounds.midX, y: bounds.maxY - halfGrip)
+            case .bottomRight:
+                center = CGPoint(x: bounds.maxX - halfGrip, y: bounds.maxY - halfGrip)
+            }
+            
+            gripView.center = center
+        }
+    }
+    
+    private func updateAppearance() {
+        borderLayer?.fillColor = fillColor.cgColor
+        borderLayer?.strokeColor = borderColor.cgColor
+        borderLayer?.lineWidth = borderWidth
+    }
+    
+    // MARK: - Gesture Handling
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: superview)
+        
+        switch gesture.state {
+        case .began:
+            initialFrame = frame
+            initialTouchPoint = gesture.location(in: superview)
+            delegate?.selectionView(self, didBeginSelection: frame)
+            
+        case .changed:
+            let newFrame = CGRect(
+                x: initialFrame.origin.x + translation.x,
+                y: initialFrame.origin.y + translation.y,
+                width: initialFrame.width,
+                height: initialFrame.height
+            )
+            frame = newFrame
+            delegate?.selectionView(self, didChangeFrame: frame)
+            
+        case .ended, .cancelled:
+            delegate?.selectionView(self, didEndSelection: frame)
+            
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - GripViewDelegate
+extension SelectionView: GripViewDelegate {
+    func gripView(_ gripView: GripView, didPanWithTranslation translation: CGPoint, state: UIGestureRecognizer.State) {
+        switch state {
+        case .began:
+            initialFrame = frame
+            delegate?.selectionView(self, didBeginSelection: frame)
+            
+        case .changed:
+            let newFrame = calculateNewFrame(for: gripView.position, translation: translation)
+            frame = newFrame
+            delegate?.selectionView(self, didChangeFrame: frame)
+            
+        case .ended, .cancelled:
+            delegate?.selectionView(self, didEndSelection: frame)
+            
+        default:
+            break
+        }
+    }
+    
+    private func calculateNewFrame(for position: GripPosition, translation: CGPoint) -> CGRect {
+        var newFrame = initialFrame
+        
+        switch position {
+        case .topLeft:
+            newFrame.origin.x += translation.x
+            newFrame.origin.y += translation.y
+            newFrame.size.width -= translation.x
+            newFrame.size.height -= translation.y
+            
+        case .topCenter:
+            newFrame.origin.y += translation.y
+            newFrame.size.height -= translation.y
+            
+        case .topRight:
+            newFrame.origin.y += translation.y
+            newFrame.size.width += translation.x
+            newFrame.size.height -= translation.y
+            
+        case .centerLeft:
+            newFrame.origin.x += translation.x
+            newFrame.size.width -= translation.x
+            
+        case .centerRight:
+            newFrame.size.width += translation.x
+            
+        case .bottomLeft:
+            newFrame.origin.x += translation.x
+            newFrame.size.width -= translation.x
+            newFrame.size.height += translation.y
+            
+        case .bottomCenter:
+            newFrame.size.height += translation.y
+            
+        case .bottomRight:
+            newFrame.size.width += translation.x
+            newFrame.size.height += translation.y
+        }
+        
+        // Ensure minimum size
+        newFrame.size.width = max(newFrame.size.width, 50)
+        newFrame.size.height = max(newFrame.size.height, 30)
+        
+        return newFrame
+    }
+}


### PR DESCRIPTION
Add a customizable `SelectionView` with interactive resize grips and a demo `TabSelectionViewController` to enable content selection similar to Songsterr app tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbde619c-9d3e-4e34-a10d-a8070defbaf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbde619c-9d3e-4e34-a10d-a8070defbaf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

